### PR TITLE
Adding Some::create() method to keep API consistent with None()

### DIFF
--- a/src/PhpOption/Some.php
+++ b/src/PhpOption/Some.php
@@ -27,6 +27,11 @@ final class Some extends Option
         $this->value = $value;
     }
 
+    public static function create($value)
+    {
+        return new self($value);
+    }
+
     public function isDefined()
     {
         return true;

--- a/tests/PhpOption/Tests/SomeTest.php
+++ b/tests/PhpOption/Tests/SomeTest.php
@@ -12,4 +12,13 @@ class SomeTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $some->getOrCall('does_not_exist'));
         $this->assertFalse($some->isEmpty());
     }
+
+    public function testCreate()
+    {
+        $some = \PhpOption\Some::create('foo');
+        $this->assertEquals('foo', $some->get());
+        $this->assertEquals('foo', $some->getOrElse(null));
+        $this->assertEquals('foo', $some->getOrCall('does_not_exist'));
+        $this->assertFalse($some->isEmpty());
+    }
 }


### PR DESCRIPTION
Ads `PhpOption\Some::create()` to provide a consistent API with `PhpOption\None`
