### PR TITLE
fix support for php 5.3

### DIFF
--- a/src/PhpOption/Option.php
+++ b/src/PhpOption/Option.php
@@ -64,11 +64,16 @@ abstract class Option implements IteratorAggregate
      */
     public static function fromArraysValue($array, $key)
     {
-        if ( ! isset($array[$key])) {
+        if ( ! self::isLikeAnArray($array) || ! isset($array[$key])) {
             return None::create();
         }
 
         return new Some($array[$key]);
+    }
+
+    private static function isLikeAnArray($array)
+    {
+        return is_array($array) || $array instanceof \ArrayAccess;
     }
 
     /**

--- a/tests/PhpOption/Tests/NoneTest.php
+++ b/tests/PhpOption/Tests/NoneTest.php
@@ -116,8 +116,9 @@ class NoneTest extends \PHPUnit_Framework_TestCase
 
     public function testFoldLeftRight()
     {
-        $this->assertSame(1, $this->none->foldLeft(1, function() { $this->fail(); }));
-        $this->assertSame(1, $this->none->foldRight(1, function() { $this->fail(); }));
+        $that = $this;
+        $this->assertSame(1, $this->none->foldLeft(1, function() use($that) { $that->fail(); }));
+        $this->assertSame(1, $this->none->foldRight(1, function() use($that) { $that->fail(); }));
     }
 
     protected function setUp()

--- a/tests/PhpOption/Tests/OptionTest.php
+++ b/tests/PhpOption/Tests/OptionTest.php
@@ -28,6 +28,10 @@ class OptionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(None::create(), Option::fromArraysValue(array('foo' => 'bar'), 'baz'));
         $this->assertEquals(None::create(), Option::fromArraysValue(array('foo' => null), 'foo'));
         $this->assertEquals(new Some('foo'), Option::fromArraysValue(array('foo' => 'foo'), 'foo'));
+
+        $this->assertEquals(None::create(), Option::fromArraysValue(new \ArrayObject(array('foo' => 'bar')), 'baz'));
+        $this->assertEquals(None::create(), Option::fromArraysValue(new \ArrayObject(array('foo' => null)), 'foo'));
+        $this->assertEquals(new Some('foo'), Option::fromArraysValue(new \ArrayObject(array('foo' => 'foo')), 'foo'));
     }
 
     public function testFromReturn()

--- a/tests/PhpOption/Tests/SomeTest.php
+++ b/tests/PhpOption/Tests/SomeTest.php
@@ -110,16 +110,18 @@ class SomeTest extends \PHPUnit_Framework_TestCase
     {
         $some = new Some(5);
 
-        $this->assertSame(6, $some->foldLeft(1, function($a, $b) {
-            $this->assertEquals(1, $a);
-            $this->assertEquals(5, $b);
+        $that = $this;
+
+        $this->assertSame(6, $some->foldLeft(1, function($a, $b) use($that) {
+            $that->assertEquals(1, $a);
+            $that->assertEquals(5, $b);
 
             return $a + $b;
         }));
 
-        $this->assertSame(6, $some->foldRight(1, function($a, $b) {
-            $this->assertEquals(1, $b);
-            $this->assertEquals(5, $a);
+        $this->assertSame(6, $some->foldRight(1, function($a, $b) use($that) {
+            $that->assertEquals(1, $b);
+            $that->assertEquals(5, $a);
 
             return $a + $b;
         }));


### PR DESCRIPTION
In travis.yml support for php 5.3 is declared, but tests are falling. I have fixed tests that was using php 5.4 features and `Option::fromArraysValue` method because as you can see one test is falling on php 5.3: https://travis-ci.org/schmittjoh/php-option/jobs/19980334
