### PR TITLE
Change Some::map() method semantics

### DIFF
--- a/src/PhpOption/Option.php
+++ b/src/PhpOption/Option.php
@@ -208,7 +208,8 @@ abstract class Option implements IteratorAggregate
 
     /**
      * Applies the callable to the value of the option if it is non-empty,
-     * and returns the return value of the callable wrapped in Some().
+     * and returns the return value of the callable wrapped in Some() when
+     * the value is not null, otherwise returns None()
      *
      * If the option is empty, then the callable is not applied.
      *

--- a/src/PhpOption/Some.php
+++ b/src/PhpOption/Some.php
@@ -86,7 +86,7 @@ final class Some extends Option
 
     public function map($callable)
     {
-        return new self(call_user_func($callable, $this->value));
+        return Option::fromValue(call_user_func($callable, $this->value));
     }
 
     public function flatMap($callable)

--- a/tests/PhpOption/Tests/SomeTest.php
+++ b/tests/PhpOption/Tests/SomeTest.php
@@ -2,6 +2,7 @@
 
 namespace PhpOption\Tests;
 
+use PhpOption\None;
 use PhpOption\Some;
 
 class SomeTest extends \PHPUnit_Framework_TestCase
@@ -61,6 +62,12 @@ class SomeTest extends \PHPUnit_Framework_TestCase
     {
         $some = new Some('foo');
         $this->assertEquals('o', $some->map(function($v) { return substr($v, 1, 1); })->get());
+    }
+
+    public function testMapToNull()
+    {
+        $some = new Some('foo');
+        $this->assertSame(None::create(), $some->map(function($v) { return null; }));
     }
 
     public function testFlatMap()


### PR DESCRIPTION
When callback, that was passed to map method, returns `null`, `Some(null)` object will be returned. This behaviour is the same as in Scala, but I have doubts this behaviour meets php world correctly. I think in scala `map` works in that way, because `null` value in this language should not be used at all, so `map` method should never return `null`.

In java8 on the other hand when callback produces null value, the `None` is returned.This behaviour differs from scala, because in java `null` is a normal value - it is fully supported by the language from the begining. I think the `null` value in php also is not unusual, so `Some` should take into accout that callback is able to return `null` value and handle this in natural for php way. Thanks to that behaviour, `Option` would be safer, it would be possible that code:

``` php
//helper function
function prop($name) { ... }

$email = Option::fromValue($employee)
    ->map(prop('boss'))
    //if boss is null, None will be returned so we can safetly invoke another map, filter etc.
    ->map(prop('email'))
    ->getOrElse('fallback@example.com');
```

I know there is `flatMap` that supports Option as return value of callback - but this enforces whole our code in every level and every layer to use `Option` type.
