### PR TITLE
Use local phpunit, ignore composer.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 vendor/
 phpunit.xml
-
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,9 @@
     "require": {
         "php": ">=5.3.0"
     },
+    "require-dev": {
+        "phpunit/phpunit": "4.7.*"
+    },
     "autoload": {
         "psr-0": { "PhpOption\\": "src/" }
     },


### PR DESCRIPTION
It is very better to use local phpunit.
Sorry for mistake in commit message.