### PR TITLE
Add Option::fromNonNullable and tests

### DIFF
--- a/src/PhpOption/Option.php
+++ b/src/PhpOption/Option.php
@@ -50,6 +50,36 @@ abstract class Option implements IteratorAggregate
     }
 
     /**
+     * Creates an option given a value that is required to exist (not the passed none value or None).
+     * Throws an exception if passed a none value or None, intended to fail fast in situations
+     * where a value is required to exist when the Option is first created.
+     *
+     * If passed a none value or None, throws an exception
+     * If passed anything else, passes the value to the Option::ensure method and returns the result
+     *
+     * @param Option|\Closure|mixed|null $value
+     * @param null|mixed $noneValue value or object to regard as null, in addition to None()
+     * @param string $exception a custom exception type to throw for a null value, defaults to \Exception
+     * @param string $message a custom exception message
+     *
+     * @return Option
+     */
+    public static function fromNonNullable(
+        $value,
+        $noneValue = null,
+        $exception = '\Exception',
+        $message = 'Option was passed an unexpected null value to a method that does not allow null values.'
+    ) {
+        $option = static::ensure($value, $noneValue);
+
+        if ($option === None::create()) {
+            throw new $exception($message);
+        }
+
+        return $option;
+    }
+
+    /**
      * Creates an option from an array's value.
      *
      * If the key does not exist in the array, the array is not actually an array, or the

--- a/src/PhpOption/Option.php
+++ b/src/PhpOption/Option.php
@@ -62,6 +62,8 @@ abstract class Option implements IteratorAggregate
      * @param string $exception a custom exception type to throw for a null value, defaults to \Exception
      * @param string $message a custom exception message
      *
+     * @throws \Exception
+     *
      * @return Option
      */
     public static function fromNonNullable(

--- a/tests/PhpOption/Tests/OptionTest.php
+++ b/tests/PhpOption/Tests/OptionTest.php
@@ -21,6 +21,23 @@ class OptionTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('PhpOption\Some', \PhpOption\Option::fromValue(null, false));
     }
 
+    public function testFromNonNullableWithNull()
+    {
+        $this->setExpectedException('\Exception', 'Option was passed an unexpected null value to a method that does not allow null values.');
+        \PhpOption\Option::fromNonNullable(null);
+    }
+
+    public function testFromNonNullableWithNone()
+    {
+        $this->setExpectedException('\Exception', 'Option was passed an unexpected null value to a method that does not allow null values.');
+        \PhpOption\Option::fromNonNullable(None::create());
+    }
+
+    public function testFromNonNullableWithValue()
+    {
+        $this->assertEquals(new Some('foo'), Option::fromNonNullable('foo'));
+    }
+
     public function testFromArraysValue()
     {
         $this->assertEquals(None::create(), Option::fromArraysValue('foo', 'bar'));


### PR DESCRIPTION
Adds a fromNonNullable method to Option so that it's possible to fail fast(er) where an initial value is required and expected to exist when the option is created and None is not initially acceptable.
