### PR TITLE
OptionTest::testFromArraysValue failure.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_script:
   - php composer.phar install --dev
 
 script:
-  - phpunit --configuration phpunit.xml --colors --coverage-text
+  - phpunit --configuration phpunit.xml.dist
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_script:
   - php composer.phar install --dev
 
 script:
-  - phpunit
+  - phpunit --configuration phpunit.xml --colors --coverage-text
 
 matrix:
   allow_failures:

--- a/src/PhpOption/Option.php
+++ b/src/PhpOption/Option.php
@@ -28,28 +28,6 @@ use IteratorAggregate;
 abstract class Option implements IteratorAggregate
 {
     /**
-     * Creates an option given a return value.
-     *
-     * This is intended for consuming existing APIs and allows you to easily
-     * convert them to an option. By default, we treat ``null`` as the None case,
-     * and everything else as Some.
-     *
-     * @param mixed $value The actual return value.
-     * @param mixed $noneValue The value which should be considered "None"; null
-     *                         by default.
-     *
-     * @return Option
-     */
-    public static function fromValue($value, $noneValue = null)
-    {
-        if ($value === $noneValue) {
-            return None::create();
-        }
-
-        return new Some($value);
-    }
-
-    /**
      * Creates an option from an array's value.
      *
      * If the key does not exist in the array, the array is not actually an array, or the
@@ -66,11 +44,10 @@ abstract class Option implements IteratorAggregate
     {
         if ( ! isset($array[$key])) {
             return None::create();
+        } else {
+            return new Some($array[$key]);
         }
-
-        return new Some($array[$key]);
     }
-
     /**
      * Creates a lazy-option with the given callback.
      *
@@ -97,7 +74,6 @@ abstract class Option implements IteratorAggregate
             return new Some($return);
         });
     }
-
     /**
      * Option factory, which creates new option based on passed value.
      * If value is already an option, it simply returns
@@ -128,7 +104,27 @@ abstract class Option implements IteratorAggregate
             return Option::fromValue($value, $noneValue);
         }
     }
+    /**
+     * Creates an option given a return value.
+     *
+     * This is intended for consuming existing APIs and allows you to easily
+     * convert them to an option. By default, we treat ``null`` as the None case,
+     * and everything else as Some.
+     *
+     * @param mixed $value The actual return value.
+     * @param mixed $noneValue The value which should be considered "None"; null
+     *                         by default.
+     *
+     * @return Option
+     */
+    public static function fromValue($value, $noneValue = null)
+    {
+        if ($value === $noneValue) {
+            return None::create();
+        }
 
+        return new Some($value);
+    }
     /**
      * Returns the value if available, or throws an exception otherwise.
      *

--- a/tests/PhpOption/Tests/LazyOptionTest.php
+++ b/tests/PhpOption/Tests/LazyOptionTest.php
@@ -3,6 +3,8 @@
 namespace PhpOption\Tests;
 
 use PhpOption\LazyOption;
+use PhpOption\None;
+use PhpOption\Some;
 
 class LazyOptionTest extends \PHPUnit_Framework_TestCase
 {
@@ -18,13 +20,13 @@ class LazyOptionTest extends \PHPUnit_Framework_TestCase
 
     public function testGetWithArgumentsAndConstructor()
     {
-        $some = \PhpOption\LazyOption::create(array($this->subject, 'execute'), array('foo'));
+        $some = LazyOption::create(array($this->subject, 'execute'), array('foo'));
 
         $this->subject
             ->expects($this->once())
             ->method('execute')
             ->with('foo')
-            ->will($this->returnValue(\PhpOption\Some::create('foo')));
+            ->will($this->returnValue(Some::create('foo')));
 
         $this->assertEquals('foo', $some->get());
         $this->assertEquals('foo', $some->getOrElse(null));
@@ -35,13 +37,13 @@ class LazyOptionTest extends \PHPUnit_Framework_TestCase
 
     public function testGetWithArgumentsAndCreate()
     {
-        $some = new \PhpOption\LazyOption(array($this->subject, 'execute'), array('foo'));
+        $some = new LazyOption(array($this->subject, 'execute'), array('foo'));
 
         $this->subject
             ->expects($this->once())
             ->method('execute')
             ->with('foo')
-            ->will($this->returnValue(\PhpOption\Some::create('foo')));
+            ->will($this->returnValue(Some::create('foo')));
 
         $this->assertEquals('foo', $some->get());
         $this->assertEquals('foo', $some->getOrElse(null));
@@ -52,12 +54,12 @@ class LazyOptionTest extends \PHPUnit_Framework_TestCase
 
     public function testGetWithoutArgumentsAndConstructor()
     {
-        $some = new \PhpOption\LazyOption(array($this->subject, 'execute'));
+        $some = new LazyOption(array($this->subject, 'execute'));
 
         $this->subject
             ->expects($this->once())
             ->method('execute')
-            ->will($this->returnValue(\PhpOption\Some::create('foo')));
+            ->will($this->returnValue(Some::create('foo')));
 
         $this->assertEquals('foo', $some->get());
         $this->assertEquals('foo', $some->getOrElse(null));
@@ -68,12 +70,12 @@ class LazyOptionTest extends \PHPUnit_Framework_TestCase
 
     public function testGetWithoutArgumentsAndCreate()
     {
-        $option = \PhpOption\LazyOption::create(array($this->subject, 'execute'));
+        $option = LazyOption::create(array($this->subject, 'execute'));
 
         $this->subject
             ->expects($this->once())
             ->method('execute')
-            ->will($this->returnValue(\PhpOption\Some::create('foo')));
+            ->will($this->returnValue(Some::create('foo')));
 
         $this->assertTrue($option->isDefined());
         $this->assertFalse($option->isEmpty());
@@ -89,12 +91,12 @@ class LazyOptionTest extends \PHPUnit_Framework_TestCase
      */
     public function testCallbackReturnsNull()
     {
-        $option = \PhpOption\LazyOption::create(array($this->subject, 'execute'));
+        $option = LazyOption::create(array($this->subject, 'execute'));
 
         $this->subject
             ->expects($this->once())
             ->method('execute')
-            ->will($this->returnValue(\PhpOption\None::create()));
+            ->will($this->returnValue(None::create()));
 
         $this->assertFalse($option->isDefined());
         $this->assertTrue($option->isEmpty());
@@ -110,7 +112,7 @@ class LazyOptionTest extends \PHPUnit_Framework_TestCase
      */
     public function testExceptionIsThrownIfCallbackReturnsNonOption()
     {
-        $option = \PhpOption\LazyOption::create(array($this->subject, 'execute'));
+        $option = LazyOption::create(array($this->subject, 'execute'));
 
         $this->subject
             ->expects($this->once())
@@ -121,24 +123,24 @@ class LazyOptionTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Invalid callback given
      */
     public function testInvalidCallbackAndConstructor()
     {
-        new \PhpOption\LazyOption('invalidCallback');
+        new LazyOption('invalidCallback');
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Invalid callback given
      */
     public function testInvalidCallbackAndCreate()
     {
-        \PhpOption\LazyOption::create('invalidCallback');
+        LazyOption::create('invalidCallback');
     }
 
-    public function testifDefined()
+    public function testIfDefined()
     {
         $called = false;
         $self = $this;
@@ -162,10 +164,10 @@ class LazyOptionTest extends \PHPUnit_Framework_TestCase
 
     public function testOrElse()
     {
-        $some = \PhpOption\Some::create('foo');
-        $lazy = \PhpOption\LazyOption::create(function() use ($some) {return $some;});
-        $this->assertSame($some, $lazy->orElse(\PhpOption\None::create()));
-        $this->assertSame($some, $lazy->orElse(\PhpOption\Some::create('bar')));
+        $some = Some::create('foo');
+        $lazy = LazyOption::create(function() use ($some) {return $some;});
+        $this->assertSame($some, $lazy->orElse(None::create()));
+        $this->assertSame($some, $lazy->orElse(Some::create('bar')));
     }
 
     public function testFoldLeftRight()

--- a/tests/PhpOption/Tests/NoneTest.php
+++ b/tests/PhpOption/Tests/NoneTest.php
@@ -3,9 +3,13 @@
 namespace PhpOption\Tests;
 
 use PhpOption\None;
+use PhpOption\Some;
 
 class NoneTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var None
+     */
     private $none;
 
     /**
@@ -13,19 +17,19 @@ class NoneTest extends \PHPUnit_Framework_TestCase
      */
     public function testGet()
     {
-        $none = \PhpOption\None::create();
+        $none = None::create();
         $none->get();
     }
 
     public function testGetOrElse()
     {
-        $none = \PhpOption\None::create();
+        $none = None::create();
         $this->assertEquals('foo', $none->getOrElse('foo'));
     }
 
     public function testGetOrCall()
     {
-        $none = \PhpOption\None::create();
+        $none = None::create();
         $this->assertEquals('foo', $none->getOrCall(function() { return 'foo'; }));
     }
 
@@ -40,14 +44,14 @@ class NoneTest extends \PHPUnit_Framework_TestCase
 
     public function testIsEmpty()
     {
-        $none = \PhpOption\None::create();
+        $none = None::create();
         $this->assertTrue($none->isEmpty());
     }
 
     public function testOrElse()
     {
-        $option = \PhpOption\Some::create('foo');
-        $this->assertSame($option, \PhpOption\None::create()->orElse($option));
+        $option = Some::create('foo');
+        $this->assertSame($option, None::create()->orElse($option));
     }
 
     public function testifDefined()
@@ -104,7 +108,7 @@ class NoneTest extends \PHPUnit_Framework_TestCase
 
     public function testForeach()
     {
-        $none = \PhpOption\None::create();
+        $none = None::create();
 
         $called = 0;
         foreach ($none as $value) {

--- a/tests/PhpOption/Tests/OptionTest.php
+++ b/tests/PhpOption/Tests/OptionTest.php
@@ -2,23 +2,24 @@
 
 namespace PhpOption\Tests;
 
+use PhpOption\LazyOption;
 use PhpOption\None;
 use PhpOption\Option;
 use PhpOption\Some;
 
 class OptionTest extends \PHPUnit_Framework_TestCase
 {
-    public function testfromValueWithDefaultNoneValue()
+    public function testFromValueWithDefaultNoneValue()
     {
-        $this->assertInstanceOf('PhpOption\None', \PhpOption\Option::fromValue(null));
-        $this->assertInstanceOf('PhpOption\Some', \PhpOption\Option::fromValue('value'));
+        $this->assertInstanceOf('PhpOption\None', Option::fromValue(null));
+        $this->assertInstanceOf('PhpOption\Some', Option::fromValue('value'));
     }
 
     public function testFromValueWithFalseNoneValue()
     {
-        $this->assertInstanceOf('PhpOption\None', \PhpOption\Option::fromValue(false, false));
-        $this->assertInstanceOf('PhpOption\Some', \PhpOption\Option::fromValue('value', false));
-        $this->assertInstanceOf('PhpOption\Some', \PhpOption\Option::fromValue(null, false));
+        $this->assertInstanceOf('PhpOption\None', Option::fromValue(false, false));
+        $this->assertInstanceOf('PhpOption\Some', Option::fromValue('value', false));
+        $this->assertInstanceOf('PhpOption\Some', Option::fromValue(null, false));
     }
 
     public function testFromArraysValue()
@@ -36,25 +37,25 @@ class OptionTest extends \PHPUnit_Framework_TestCase
         $false = function() { return false; };
         $some = function() { return 'foo'; };
 
-        $this->assertTrue(\PhpOption\Option::fromReturn($null)->isEmpty());
-        $this->assertFalse(\PhpOption\Option::fromReturn($false)->isEmpty());
-        $this->assertTrue(\PhpOption\Option::fromReturn($false, array(), false)->isEmpty());
-        $this->assertTrue(\PhpOption\Option::fromReturn($some)->isDefined());
-        $this->assertFalse(\PhpOption\Option::fromReturn($some, array(), 'foo')->isDefined());
+        $this->assertTrue(Option::fromReturn($null)->isEmpty());
+        $this->assertFalse(Option::fromReturn($false)->isEmpty());
+        $this->assertTrue(Option::fromReturn($false, array(), false)->isEmpty());
+        $this->assertTrue(Option::fromReturn($some)->isDefined());
+        $this->assertFalse(Option::fromReturn($some, array(), 'foo')->isDefined());
     }
 
     public function testOrElse()
     {
-        $a = new \PhpOption\Some('a');
-        $b = new \PhpOption\Some('b');
+        $a = new Some ('a');
+        $b = new Some ('b');
 
         $this->assertEquals('a', $a->orElse($b)->get());
     }
 
     public function testOrElseWithNoneAsFirst()
     {
-        $a = \PhpOption\None::create();
-        $b = new \PhpOption\Some('b');
+        $a = None::create();
+        $b = new Some ('b');
 
         $this->assertEquals('b', $a->orElse($b)->get());
     }
@@ -63,18 +64,18 @@ class OptionTest extends \PHPUnit_Framework_TestCase
     {
         $throws = function() { throw new \LogicException('Should never be called.'); };
 
-        $a = new \PhpOption\Some('a');
-        $b = new \PhpOption\LazyOption($throws);
+        $a = new Some ('a');
+        $b = new LazyOption($throws);
 
         $this->assertEquals('a', $a->orElse($b)->get());
     }
 
     public function testOrElseWithMultipleAlternatives()
     {
-        $throws = new \PhpOption\LazyOption(function() { throw new \LogicException('Should never be called.'); });
-        $returns = new \PhpOption\LazyOption(function() { return new \PhpOption\Some('foo'); });
+        $throws = new LazyOption(function() { throw new \LogicException('Should never be called.'); });
+        $returns = new LazyOption(function() { return new Some ('foo'); });
 
-        $a = \PhpOption\None::create();
+        $a = None::create();
 
         $this->assertEquals('foo', $a->orElse($returns)->orElse($throws)->get());
     }

--- a/tests/PhpOption/Tests/PerformanceTest.php
+++ b/tests/PhpOption/Tests/PerformanceTest.php
@@ -2,12 +2,22 @@
 
 namespace PhpOption\Tests;
 
+use PhpOption\None;
+use PhpOption\Some;
+
 /**
  * @group performance
  */
 class PerformanceTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var TraditionalRepo
+     */
     private $traditionalRepo;
+
+    /**
+     * @var PhpOptionRepo
+     */
     private $phpOptionRepo;
 
     public function testSomeCase()
@@ -74,9 +84,9 @@ class PhpOptionRepo
     public function findMaybe($success)
     {
         if ($success) {
-            return new \PhpOption\Some(new \stdClass);
+            return new Some(new \stdClass);
         }
 
-        return \PhpOption\None::create();
+        return None::create();
     }
 }

--- a/tests/PhpOption/Tests/SomeTest.php
+++ b/tests/PhpOption/Tests/SomeTest.php
@@ -2,13 +2,14 @@
 
 namespace PhpOption\Tests;
 
+use PhpOption\None;
 use PhpOption\Some;
 
 class SomeTest extends \PHPUnit_Framework_TestCase
 {
     public function testGet()
     {
-        $some = new \PhpOption\Some('foo');
+        $some = new Some('foo');
         $this->assertEquals('foo', $some->get());
         $this->assertEquals('foo', $some->getOrElse(null));
         $this->assertEquals('foo', $some->getOrCall('does_not_exist'));
@@ -18,7 +19,7 @@ class SomeTest extends \PHPUnit_Framework_TestCase
 
     public function testCreate()
     {
-        $some = \PhpOption\Some::create('foo');
+        $some = Some::create('foo');
         $this->assertEquals('foo', $some->get());
         $this->assertEquals('foo', $some->getOrElse(null));
         $this->assertEquals('foo', $some->getOrCall('does_not_exist'));
@@ -28,12 +29,12 @@ class SomeTest extends \PHPUnit_Framework_TestCase
 
     public function testOrElse()
     {
-        $some = \PhpOption\Some::create('foo');
-        $this->assertSame($some, $some->orElse(\PhpOption\None::create()));
-        $this->assertSame($some, $some->orElse(\PhpOption\Some::create('bar')));
+        $some = Some::create('foo');
+        $this->assertSame($some, $some->orElse(None::create()));
+        $this->assertSame($some, $some->orElse(None::create('bar')));
     }
 
-    public function testifDefined()
+    public function testIfDefined()
     {
         $called = false;
         $self = $this;
@@ -157,7 +158,7 @@ class Repository
     public function getLastRegisteredUsername()
     {
         if (empty($this->users)) {
-            return \PhpOption\None::create();
+            return None::create();
         }
 
         return new Some(end($this->users));
@@ -170,7 +171,7 @@ class Repository
             return new Some(array('name' => $name));
         }
 
-        return \PhpOption\None::create();
+        return None::create();
     }
 
     public function getDefaultUser()

--- a/tests/PhpOption/Tests/SomeTest.php
+++ b/tests/PhpOption/Tests/SomeTest.php
@@ -112,15 +112,15 @@ class SomeTest extends \PHPUnit_Framework_TestCase
         $some = new Some(5);
 
         $this->assertSame(6, $some->foldLeft(1, function($a, $b) {
-            $this->assertEquals(1, $a);
-            $this->assertEquals(5, $b);
+            \PHPUnit_Framework_Assert::assertEquals(1, $a);
+            \PHPUnit_Framework_Assert::assertEquals(5, $b);
 
             return $a + $b;
         }));
 
         $this->assertSame(6, $some->foldRight(1, function($a, $b) {
-            $this->assertEquals(1, $b);
-            $this->assertEquals(5, $a);
+            \PHPUnit_Framework_Assert::assertEquals(1, $b);
+            \PHPUnit_Framework_Assert::assertEquals(5, $a);
 
             return $a + $b;
         }));

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,6 +3,6 @@
 if ( ! is_file($autoloadFile = __DIR__.'/../vendor/autoload.php')) {
     echo 'Could not find "vendor/autoload.php". Did you forget to run "composer install --dev"?'.PHP_EOL;
     exit(1);
+} else {
+    require_once $autoloadFile;
 }
-
-require_once $autoloadFile;


### PR DESCRIPTION
Hi!

I was playing with your code and I managed to solve the SomeTest.php failures in PHP 5.3, but that brought me to another failure, which is mentioned in the title of the pull request.

The error from Travis CI is the following:

```
There was 1 failure:
1) PhpOption\Tests\OptionTest::testFromArraysValue
PhpOption\Some Object &000000003ae7df3b0000000070465854 (
    'value' => 'f'
) is not instance of expected class "PhpOption\None".
--- Expected
+++ Actual
@@ @@
-PhpOption\None Object &000000003ae7dfef0000000070465854 ()
+PhpOption\Some Object &000000003ae7df3b0000000070465854 (
+    'value' => 'f'
+)
/home/travis/build/IlyaBakhlin/php-option/tests/PhpOption/Tests/OptionTest.php:27
phar:///home/travis/.phpenv/versions/5.3.29/bin/phpunit/phpunit/TextUI/Command.php:152
phar:///home/travis/.phpenv/versions/5.3.29/bin/phpunit/phpunit/TextUI/Command.php:104
FAILURES!
Tests: 54, Assertions: 146, Failures: 1.
```

I don't know if I've broken something or just discovered a new bug.

Sorry and thank you.