### PR TITLE
Use proper license identifier

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Option Type for PHP",
     "keywords": ["php","option","language","type"],
     "type": "library",
-    "license": "Apache2",
+    "license": "Apache-2.0",
     "authors": [
         {
             "name": "Johannes M. Schmitt",


### PR DESCRIPTION
The correct identifier for the Apache 2 license is `Apache-2.0` and not `Apache2`. This pull request will stop the warnings from `composer validate´.

```
License "Apache2" is not a valid SPDX license identifier, see https://spdx.org/licenses/ if you use an open license.
If the software is closed-source, you may use "proprietary" as license.
```
