### PR TITLE
Update Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,22 @@
 language: php
+
 php:
   - 5.3
   - 5.4
   - 5.5
+  - 5.6
+  - 7.0
   - hhvm
+  - nightly
 
-before_script:
-  - wget http://getcomposer.org/composer.phar
-  - php composer.phar install --dev
+sudo: false
 
-script:
-  - phpunit
+cache:
+  directories:
+    - $HOME/.composer/cache/files
+
+install:
+  - composer install --dev
 
 matrix:
   allow_failures:


### PR DESCRIPTION
- composer is automatically installed
- use the 'install' to perform composer
- phpunit is the default
- add newest PHP version
- cache composer files to speed up tests
