### PR TITLE
Option::fromArraysValue() corrected

### DIFF
--- a/src/PhpOption/Option.php
+++ b/src/PhpOption/Option.php
@@ -64,7 +64,7 @@ abstract class Option implements IteratorAggregate
      */
     public static function fromArraysValue($array, $key)
     {
-        if ( ! isset($array[$key])) {
+        if (!is_array($array) || !isset($array[$key])) {
             return None::create();
         }
 

--- a/tests/PhpOption/Tests/SomeTest.php
+++ b/tests/PhpOption/Tests/SomeTest.php
@@ -110,9 +110,10 @@ class SomeTest extends \PHPUnit_Framework_TestCase
     {
         $some = new Some(5);
 
-        $this->assertSame(6, $some->foldLeft(1, function($a, $b) {
-            $this->assertEquals(1, $a);
-            $this->assertEquals(5, $b);
+        $testObj = $this;
+        $this->assertSame(6, $some->foldLeft(1, function($a, $b) use ($testObj) {
+            $testObj->assertEquals(1, $a);
+            $testObj->assertEquals(5, $b);
 
             return $a + $b;
         }));

--- a/tests/PhpOption/Tests/SomeTest.php
+++ b/tests/PhpOption/Tests/SomeTest.php
@@ -118,9 +118,9 @@ class SomeTest extends \PHPUnit_Framework_TestCase
             return $a + $b;
         }));
 
-        $this->assertSame(6, $some->foldRight(1, function($a, $b) {
-            $this->assertEquals(1, $b);
-            $this->assertEquals(5, $a);
+        $this->assertSame(6, $some->foldRight(1, function($a, $b) use ($testObj) {
+            $testObj->assertEquals(1, $b);
+            $testObj->assertEquals(5, $a);
 
             return $a + $b;
         }));


### PR DESCRIPTION
If the first parameter is not and array, PhpOption\None is now returned. Before this commit, a string could be used and one of its characters could be accessed.