### PR TITLE
Support ArrayAccess on `fromArraysValue`

### DIFF
--- a/src/PhpOption/Option.php
+++ b/src/PhpOption/Option.php
@@ -56,14 +56,14 @@ abstract class Option implements IteratorAggregate
      * array, or the array's value at the given key is null, None is returned.
      * Otherwise, Some is returned wrapping the value at the given key.
      *
-     * @param mixed  $array A potential array value.
+     * @param mixed  $array A potential array or \ArrayAccess value.
      * @param string $key   The key to check.
      *
      * @return Option
      */
     public static function fromArraysValue($array, $key)
     {
-        if (!is_array($array) || !isset($array[$key])) {
+        if ($array === null || !isset($array[$key])) {
             return None::create();
         }
 

--- a/src/PhpOption/Option.php
+++ b/src/PhpOption/Option.php
@@ -18,6 +18,7 @@
 
 namespace PhpOption;
 
+use ArrayAccess;
 use IteratorAggregate;
 
 /**
@@ -63,7 +64,7 @@ abstract class Option implements IteratorAggregate
      */
     public static function fromArraysValue($array, $key)
     {
-        if ($array === null || !isset($array[$key])) {
+        if (!(is_array($array) || $array instanceof ArrayAccess) || !isset($array[$key])) {
             return None::create();
         }
 

--- a/tests/PhpOption/Tests/OptionTest.php
+++ b/tests/PhpOption/Tests/OptionTest.php
@@ -2,6 +2,8 @@
 
 namespace PhpOption\Tests;
 
+use ArrayAccess;
+use LogicException;
 use PhpOption\LazyOption;
 use PhpOption\None;
 use PhpOption\Option;
@@ -73,7 +75,7 @@ class OptionTest extends TestCase
     public function testOrElseWithLazyOptions()
     {
         $throws = function () {
-            throw new \LogicException('Should never be called.');
+            throw new LogicException('Should never be called.');
         };
 
         $a = new Some('a');
@@ -85,7 +87,7 @@ class OptionTest extends TestCase
     public function testOrElseWithMultipleAlternatives()
     {
         $throws = new LazyOption(function () {
-            throw new \LogicException('Should never be called.');
+            throw new LogicException('Should never be called.');
         });
         $returns = new LazyOption(function () {
             return new Some('foo');
@@ -128,7 +130,7 @@ class OptionTest extends TestCase
     }
 }
 
-class SomeArrayObject implements \ArrayAccess
+class SomeArrayObject implements ArrayAccess
 {
     private $data = [];
 
@@ -151,5 +153,4 @@ class SomeArrayObject implements \ArrayAccess
     {
         unset($this->data[$offset]);
     }
-
 }

--- a/tests/PhpOption/Tests/OptionTest.php
+++ b/tests/PhpOption/Tests/OptionTest.php
@@ -30,6 +30,10 @@ class OptionTest extends TestCase
         $this->assertEquals(None::create(), Option::fromArraysValue(['foo' => 'bar'], 'baz'));
         $this->assertEquals(None::create(), Option::fromArraysValue(['foo' => null], 'foo'));
         $this->assertEquals(new Some('foo'), Option::fromArraysValue(['foo' => 'foo'], 'foo'));
+
+        $object = new SomeArrayObject();
+        $object['foo'] = 'foo';
+        $this->assertEquals(new Some('foo'), Option::fromArraysValue($object, 'foo'));
     }
 
     public function testFromReturn()
@@ -122,4 +126,30 @@ class OptionTest extends TestCase
         $this->assertEquals(None::create(), $fL1());
         $this->assertEquals(Some::create(null), $fL2());
     }
+}
+
+class SomeArrayObject implements \ArrayAccess
+{
+    private $data = [];
+
+    public function offsetExists($offset)
+    {
+        return isset($this->data[$offset]);
+    }
+
+    public function offsetGet($offset)
+    {
+        return $this->data[$offset];
+    }
+
+    public function offsetSet($offset, $value)
+    {
+        $this->data[$offset] = $value;
+    }
+
+    public function offsetUnset($offset)
+    {
+        unset($this->data[$offset]);
+    }
+
 }


### PR DESCRIPTION
When we updated to 1.5.2, it actually broke our builds. It turns out that [this change](https://github.com/schmittjoh/php-option/pull/33) prevents you from providing an object that implements ArrayAccess.

This PR addresses that issue.
