### PR TITLE
Support PHPUnit 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": "^5.5.9 || ^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8.35 || ^5.0 || ^6.0 || ^7.0",
+        "phpunit/phpunit": "^4.8.35 || ^5.0 || ^6.0 || ^7.0 || ^8.0",
         "bamarni/composer-bin-plugin": "^1.3"
     },
     "autoload": {

--- a/tests/PhpOption/Tests/LazyOptionTest.php
+++ b/tests/PhpOption/Tests/LazyOptionTest.php
@@ -12,7 +12,7 @@ class LazyOptionTest extends TestCase
 {
     private $subject;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->subject = $this
             ->getMockBuilder('Subject')

--- a/tests/PhpOption/Tests/LazyOptionTest.php
+++ b/tests/PhpOption/Tests/LazyOptionTest.php
@@ -15,7 +15,7 @@ class LazyOptionTest extends TestCase
     public function setUp(): void
     {
         $this->subject = $this
-            ->getMockBuilder('Subject')
+            ->getMockBuilder(\stdClass::class)
             ->setMethods(['execute'])
             ->getMock();
     }

--- a/tests/PhpOption/Tests/LazyOptionTest.php
+++ b/tests/PhpOption/Tests/LazyOptionTest.php
@@ -87,12 +87,11 @@ class LazyOptionTest extends TestCase
         $this->assertEquals('foo', $option->getOrThrow(new \RuntimeException('does_not_exist')));
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage None has no value
-     */
     public function testCallbackReturnsNull()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('None has no value');
+
         $option = LazyOption::create([$this->subject, 'execute']);
 
         $this->subject
@@ -110,12 +109,11 @@ class LazyOptionTest extends TestCase
         $option->get();
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Expected instance of \PhpOption\Option
-     */
     public function testExceptionIsThrownIfCallbackReturnsNonOption()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Expected instance of \PhpOption\Option');
+
         $option = LazyOption::create([$this->subject, 'execute']);
 
         $this->subject
@@ -126,21 +124,17 @@ class LazyOptionTest extends TestCase
         $this->assertFalse($option->isDefined());
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage Invalid callback given
-     */
     public function testInvalidCallbackAndConstructor()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid callback given');
         new LazyOption('invalidCallback');
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage Invalid callback given
-     */
     public function testInvalidCallbackAndCreate()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid callback given');
         LazyOption::create('invalidCallback');
     }
 

--- a/tests/PhpOption/Tests/NoneTest.php
+++ b/tests/PhpOption/Tests/NoneTest.php
@@ -128,7 +128,7 @@ class NoneTest extends TestCase
         }));
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->none = None::create();
     }

--- a/tests/PhpOption/Tests/NoneTest.php
+++ b/tests/PhpOption/Tests/NoneTest.php
@@ -10,11 +10,9 @@ class NoneTest extends TestCase
 {
     private $none;
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testGet()
     {
+        $this->expectException(\RuntimeException::class);
         $none = None::create();
         $none->get();
     }
@@ -33,12 +31,10 @@ class NoneTest extends TestCase
         }));
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Not Found!
-     */
     public function testGetOrThrow()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Not Found!');
         None::create()->getOrThrow(new \RuntimeException('Not Found!'));
     }
 

--- a/tests/PhpOption/Tests/PerformanceTest.php
+++ b/tests/PhpOption/Tests/PerformanceTest.php
@@ -54,7 +54,7 @@ class PerformanceTest extends TestCase
         printf("Overhead per invocation (none case): %.9fs\n", $overheadPerInvocation);
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->traditionalRepo = new TraditionalRepo();
         $this->phpOptionRepo = new PhpOptionRepo();


### PR DESCRIPTION
These changes add support for PHPUnit 8.

1. Adds the `void` return type to the `setUp()` method.
This is required for the tests to work in PHPUnit 8.

2. Replaces deprecated annotations.
This is optional until PHPUnit 9. However, ignoring it would cause CI to fail due to warnings.

3. Uses `stdClass` to mock the "`Subject`" class.
This seemed to work either way, but PHPStan complained when passing a simple string.

Note that the mandatory change (number 1 above) will unfortunately **break compatibility with PHP < 7.1**, because the `void` return type declaration was added in 7.1.

I have not included any changes to officially end the support for older versions, though. The library itself is unaffected and thus still compatible with older versions, albeit no longer tested against those versions. You'll thus probably want to hold off on this change until you're ready to officially end pre-7.1 support.