### PR TITLE
Fix PHP 8.1 compatibility

### DIFF
--- a/src/PhpOption/Some.php
+++ b/src/PhpOption/Some.php
@@ -149,6 +149,7 @@ final class Some extends Option
         return $this;
     }
 
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator([$this->value]);


### PR DESCRIPTION
Fix for:

```
Deprecation Notice: Return type of PhpOption\Some::getIterator() should either be compatible with
IteratorAggregate::getIterator(): Traversable,
or the #[ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in
vendor/phpoption/phpoption/src/PhpOption/Some.php:152
```

which occur when loading the class in PHP 8.1