### PR TITLE
Fix Option::fromValue typing

### DIFF
--- a/src/PhpOption/Option.php
+++ b/src/PhpOption/Option.php
@@ -37,9 +37,9 @@ abstract class Option implements IteratorAggregate
      *
      * @template S
      *
-     * @param S $value     The actual return value.
-     * @param S $noneValue The value which should be considered "None"; null by
-     *                     default.
+     * @param S     $value     The actual return value.
+     * @param mixed $noneValue The value which should be considered "None"; null
+     *                         by default.
      *
      * @return Option<S>
      */


### PR DESCRIPTION
These changes fix the issue https://github.com/schmittjoh/php-option/issues/63.

> `Option::fromValue` uses the same type parameter `C` for the `$value` and `$noneValue` parameters. As a result, the type of `C` is inferred to a union of the types of `$value` and `$noneValue`.

We fix this issue by typing `$noneValue` to mixed.

Thanks to @arnaud-lb for finding the bug and suggesting this fix !