### PR TITLE
use remote location for psalm.xml XSD schema

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -4,7 +4,7 @@
     resolveFromConfigFile="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
-    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    xsi:schemaLocation="https://getpsalm.org/schema/config https://raw.githubusercontent.com/vimeo/psalm/4.x/config.xsd"
 >
     <projectFiles>
         <directory name="src" />


### PR DESCRIPTION
the previously mentioned `vendor/vimeo/psalm/config.xsd` does not actually exist, because you include PHAR version of Psalm which does not have the schema bundled, and also due to using composer bin plugin, it would be in `vendor-bin`, not in `vendor` anyway.