### PR TITLE
Added equals method

### DIFF
--- a/src/PhpOption/LazyOption.php
+++ b/src/PhpOption/LazyOption.php
@@ -155,6 +155,11 @@ final class LazyOption extends Option
         return $this->option()->foldRight($initialValue, $callable);
     }
 
+    public function equals($other, $callable): bool
+    {
+        return $this->option()->equals($other, $callable);
+    }
+
     /**
      * @return Option<T>
      */

--- a/src/PhpOption/None.php
+++ b/src/PhpOption/None.php
@@ -130,6 +130,11 @@ final class None extends Option
         return $initialValue;
     }
 
+    public function equals($other, $callable): bool
+    {
+        return $other instanceof self;
+    }
+
     private function __construct()
     {
     }

--- a/src/PhpOption/Option.php
+++ b/src/PhpOption/Option.php
@@ -177,7 +177,7 @@ abstract class Option implements IteratorAggregate
             }
 
             $args = array_map(
-                /** @return T */
+            /** @return T */
                 static function (self $o) {
                     // it is safe to do so because the fold above checked
                     // that all arguments are of type Some
@@ -413,7 +413,7 @@ abstract class Option implements IteratorAggregate
      *
      * @template S
      *
-     * @param S                $initialValue
+     * @param S $initialValue
      * @param callable(S, T):S $callable
      *
      * @return S
@@ -431,4 +431,14 @@ abstract class Option implements IteratorAggregate
      * @return S
      */
     abstract public function foldRight($initialValue, $callable);
+
+    /**
+     * Checks if the option is equal to another option based on a callable.
+     *
+     * @param callable(T, T):bool $callable
+     * @param Option<T> $other
+     *
+     * @return bool
+     */
+    abstract public function equals($other, $callable): bool;
 }

--- a/src/PhpOption/Some.php
+++ b/src/PhpOption/Some.php
@@ -166,4 +166,14 @@ final class Some extends Option
     {
         return $callable($this->value, $initialValue);
     }
+
+    public function equals($other, $callable): bool
+    {
+        if(!$other instanceof self) {
+            return false;
+        }
+
+        return $callable($this->value, $other->get());
+
+    }
 }

--- a/tests/PhpOption/Tests/LazyOptionTest.php
+++ b/tests/PhpOption/Tests/LazyOptionTest.php
@@ -197,4 +197,22 @@ class LazyOptionTest extends TestCase
         });
         self::assertSame(6, $lazyOption->foldRight(5, $callback));
     }
+
+    public function testEquals(): void
+    {
+        $some = Some::create('foo');
+        $lazyWithSameValue = LazyOption::create(function () use ($some) {
+            return $some;
+        });
+        $lazyWithOtherValue = LazyOption::create(function () {
+            return Some::create('bar');
+        });
+
+        $callback = function ($a, $b) {
+            return $a === $b;
+        };
+
+        self::assertTrue($lazyWithSameValue->equals($some, $callback));
+        self::assertFalse($lazyWithOtherValue->equals($some, $callback));
+    }
 }

--- a/tests/PhpOption/Tests/NoneTest.php
+++ b/tests/PhpOption/Tests/NoneTest.php
@@ -150,4 +150,19 @@ class NoneTest extends TestCase
             $this->fail();
         }));
     }
+
+    public function testEquals(): void
+    {
+        $none = None::create();
+        $otherNone = None::create();
+        $some = Some::create('foo');
+
+        self::assertTrue($none->equals($otherNone, function ($a, $b) {
+            throw new \Exception("ShouldNotBeCalled");
+        }));
+
+        self::assertFalse($none->equals($some, function () {
+            throw new \Exception("ShouldNotBeCalled");
+        }));
+    }
 }

--- a/tests/PhpOption/Tests/SomeTest.php
+++ b/tests/PhpOption/Tests/SomeTest.php
@@ -153,6 +153,22 @@ class SomeTest extends TestCase
         self::assertSame('foo', $extractedValue);
         self::assertSame(1, $called);
     }
+
+    public function testEquals(): void
+    {
+        $some = Some::create(3);
+        $otherSomeWithSameValue = Some::create(3);
+        $otherSomeWithDifferentValue = Some::create(4);
+        $none = None::create();
+
+        $comparator = function ($a, $b) {
+            return $a === $b;
+        };
+
+        self::assertTrue($some->equals($otherSomeWithSameValue, $comparator));
+        self::assertFalse($some->equals($otherSomeWithDifferentValue, $comparator));
+        self::assertFalse($some->equals($none, $comparator));
+    }
 }
 
 // For the interested reader of these tests, we have gone some great lengths


### PR DESCRIPTION
Given the following class I would like to have a simple method to check for equality with a callback. 

```php
final class User
{
    public function __construct(
        /** @var Option<Username> $username */
        public Option $username,
    )
    {
    }

    public function equals(self $other): bool
    {
        if (!$this->username->equals($other->username, fn(Username $a, Username $b) => $a->equals($b))) {
            return false;
        }

        return true;
    }
}
```