### PR TITLE
Allow `int` and `null` as possible types for `$key` in `Option::fromArraysValue`

### DIFF
--- a/src/PhpOption/Option.php
+++ b/src/PhpOption/Option.php
@@ -62,13 +62,13 @@ abstract class Option implements IteratorAggregate
      * @template S
      *
      * @param array<string|int,S>|ArrayAccess<string|int,S>|null $array A potential array or \ArrayAccess value.
-     * @param string                                             $key   The key to check.
+     * @param string|int|null                                    $key   The key to check.
      *
      * @return Option<S>
      */
     public static function fromArraysValue($array, $key)
     {
-        if (!(is_array($array) || $array instanceof ArrayAccess) || !isset($array[$key])) {
+        if ($key === null || !(is_array($array) || $array instanceof ArrayAccess) || !isset($array[$key])) {
             return None::create();
         }
 

--- a/tests/PhpOption/Tests/OptionTest.php
+++ b/tests/PhpOption/Tests/OptionTest.php
@@ -31,11 +31,17 @@ class OptionTest extends TestCase
         self::assertEquals(None::create(), Option::fromArraysValue(null, 'bar'));
         self::assertEquals(None::create(), Option::fromArraysValue(['foo' => 'bar'], 'baz'));
         self::assertEquals(None::create(), Option::fromArraysValue(['foo' => null], 'foo'));
+        self::assertEquals(None::create(), Option::fromArraysValue(['foo' => 'bar'], null));
         self::assertEquals(new Some('foo'), Option::fromArraysValue(['foo' => 'foo'], 'foo'));
+        self::assertEquals(new Some('foo'), Option::fromArraysValue([13 => 'foo'], 13));
 
         $object = new SomeArrayObject();
         $object['foo'] = 'foo';
         self::assertEquals(new Some('foo'), Option::fromArraysValue($object, 'foo'));
+
+        $object = new SomeArrayObject();
+        $object[13] = 'foo';
+        self::assertEquals(new Some('foo'), Option::fromArraysValue($object, 13));
     }
 
     public function testFromReturn(): void


### PR DESCRIPTION
Closes #73.