### PR TITLE
Improve `Option::select()` return type

### DIFF
--- a/src/PhpOption/Option.php
+++ b/src/PhpOption/Option.php
@@ -369,9 +369,10 @@ abstract class Option implements IteratorAggregate
      *
      * In other words, this will filter all but the passed value.
      *
-     * @param T $value
+     * @template S of T
+     * @param S $value
      *
-     * @return Option<T>
+     * @return Option<S>
      */
     abstract public function select($value);
 


### PR DESCRIPTION
This change adds a minor improvement to the return type of `Option::select()` for static analysis.

```diff
/** @var \PhpOption\Option<1|2|3> $option */
-PHPStan\dumpType($option->select(2)); // PhpOption\Option<1|2|3>
+PHPStan\dumpType($option->select(2)); // PhpOption\Option<2>
```