### PR TITLE
Fix `foldLeft` and `foldRight` return types

### DIFF
--- a/src/PhpOption/Option.php
+++ b/src/PhpOption/Option.php
@@ -412,11 +412,12 @@ abstract class Option implements IteratorAggregate
      * ```
      *
      * @template S
+     * @template R
      *
      * @param S                $initialValue
-     * @param callable(S, T):S $callable
+     * @param callable(S, T):R $callable
      *
-     * @return S
+     * @return R
      */
     abstract public function foldLeft($initialValue, $callable);
 
@@ -424,11 +425,12 @@ abstract class Option implements IteratorAggregate
      * foldLeft() but with reversed arguments for the callable.
      *
      * @template S
+     * @template R
      *
      * @param S                $initialValue
-     * @param callable(T, S):S $callable
+     * @param callable(T, S):R $callable
      *
-     * @return S
+     * @return R
      */
     abstract public function foldRight($initialValue, $callable);
 }


### PR DESCRIPTION
The following code is valid, but not allowed by template types currently. This PR fixes that.

```php
$some = new Some(5);
$result = $some->foldLeft(1, function($a, $b) { return (string) ($a + $b) }); // string("6")
```