### PR TITLE
Improve the method signature of Option::fromValue to better understand nullable/optional value

### DIFF
--- a/src/PhpOption/Option.php
+++ b/src/PhpOption/Option.php
@@ -36,9 +36,10 @@ abstract class Option implements IteratorAggregate
      * case, and everything else as Some.
      *
      * @template S
+     * @template P
      *
-     * @param S $value     The actual return value.
-     * @param S $noneValue The value which should be considered "None"; null by
+     * @param S|P $value   The actual return value.
+     * @param P $noneValue The value which should be considered "None"; null by
      *                     default.
      *
      * @return Option<S>


### PR DESCRIPTION
When using Option::fromValue($something), psalm decoded it was Option<string | null> because `$something` is of type `string | null.`

This is the psalm error I got in my codebase:
<img width="1607" alt="image" src="https://github.com/user-attachments/assets/fa3ec34a-94c9-4a98-a546-a872b375a6a4">


However, I want to let psalm know that even if I pass something like null to `Option::fromValue` ,the output is actually only `Option<string>` instead of `Option<string | null>`.